### PR TITLE
Fixed the bind this on moleculer-bull

### DIFF
--- a/packages/moleculer-bull/src/index.js
+++ b/packages/moleculer-bull/src/index.js
@@ -74,7 +74,7 @@ module.exports = function createService(url, queueOpts) {
 
 						args.push(fn.process.bind(this));
 
-						this.getQueue(name).process.apply(null, args);
+						this.getQueue(name).process(...args);
 					}
 				});
 			}


### PR DESCRIPTION
Hi @icebob!

The new release of moleculer-bull is breaking the process method of bull because is binding to null the `this` object of bull `this.getQueue(name).process.apply(null, args);`

[related line in bull](https://github.com/OptimalBits/bull/blob/443234037a4af8dd9b24eae804896d168215ecde/lib/queue.js#L626)

This PR will fix the issue.