### PR TITLE
Updated lodash for molecular-mail from 4.17.11 to 4.17.15

### DIFF
--- a/packages/moleculer-mail/package.json
+++ b/packages/moleculer-mail/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "email-templates": "2.7.1",
-    "lodash": "4.17.11",
+    "lodash": "4.17.15",
     "nodemailer": "4.6.7",
     "nodemailer-html-to-text": "2.1.0"
   }


### PR DESCRIPTION
Hello,

I'm working on on a program analysis tool for some research and I noticed you are using version 4.17.11 of lodash. lodash@4.17.11 has a vulnerability in the defaultsDeep method which is used in this repository in packages/molecular-mail/src/index.js.

This PR bumps the version of lodash to 4.17.15, the latest version as of this writing. I saw that all of your dependencies are pinned to specific versions and have respected that with this PR.

Let me know if you have any questions or would like to discuss further! Thanks!