### PR TITLE
Allow per queue settings

### DIFF
--- a/packages/moleculer-bull/src/index.js
+++ b/packages/moleculer-bull/src/index.js
@@ -48,7 +48,8 @@ module.exports = function createService(url, queueOpts) {
 			 */
 			getQueue(name) {
 				if (!this.$queues[name]) {
-					let queueOptions = this.schema.queues[name] ? this.schema.queues[name].options : null;
+					// If queue options are present 
+					let queueOptions = this.schema.queues[name].options;
 					this.$queues[name] = Queue(name, url, queueOptions ? queueOptions : queueOpts);
 				}
 				return this.$queues[name];

--- a/packages/moleculer-bull/src/index.js
+++ b/packages/moleculer-bull/src/index.js
@@ -34,10 +34,10 @@ module.exports = function createService(url, queueOpts) {
 				if(opts)
 					return this.getQueue(name).add(jobName, payload, opts);
 				else
-					if (payload)
-						return this.getQueue(name).add(jobName, payload);
-					else
-						return this.getQueue(name).add(jobName);
+				if (payload)
+					return this.getQueue(name).add(jobName, payload);
+				else
+					return this.getQueue(name).add(jobName);
 			},
 
 			/**
@@ -48,7 +48,8 @@ module.exports = function createService(url, queueOpts) {
 			 */
 			getQueue(name) {
 				if (!this.$queues[name]) {
-					this.$queues[name] = Queue(name, url, queueOpts);
+					let queueOptions = this.schema.queues[name] ? this.schema.queues[name].options : null;
+					this.$queues[name] = Queue(name, url, queueOptions ? queueOptions : queueOpts);
 				}
 				return this.$queues[name];
 			}
@@ -59,7 +60,7 @@ module.exports = function createService(url, queueOpts) {
 		},
 
 		started() {
-			const setHandler = (handler, name)=>{
+			const setHandler = (handler, name) => {
 				let args = [];
 
 				if (handler.name) {
@@ -70,10 +71,10 @@ module.exports = function createService(url, queueOpts) {
 					args.push(handler.concurrency);
 				}
 
-				args.push(handler.process.bind(this))
+				args.push(handler.process.bind(this));
 
-				this.getQueue(name).process(...args)
-			}
+				this.getQueue(name).process(...args);
+			};
 
 			if (this.schema.queues) {
 				_.forIn(this.schema.queues, (fn, name) => {
@@ -81,12 +82,12 @@ module.exports = function createService(url, queueOpts) {
 						this.getQueue(name).process(fn.bind(this));
 					else if(Array.isArray(fn)){
 						for(let handler of fn){
-							setHandler(handler, name)
+							setHandler(handler, name);
 						}
 					}else {
-						setHandler(fn, name)
+						setHandler(fn, name);
 					}
-				})
+				});
 			}
 
 			return this.Promise.resolve();

--- a/packages/moleculer-bull/src/index.js
+++ b/packages/moleculer-bull/src/index.js
@@ -48,7 +48,8 @@ module.exports = function createService(url, queueOpts) {
 			 */
 			getQueue(name) {
 				if (!this.$queues[name]) {
-					// If queue options are present 
+					// If queue options are present use them over the parent mixin options
+					// This allows a user to override the service wide queue options
 					let queueOptions = this.schema.queues[name].options;
 					this.$queues[name] = Queue(name, url, queueOptions ? queueOptions : queueOpts);
 				}

--- a/packages/moleculer-bull/test/unit/index.spec.js
+++ b/packages/moleculer-bull/test/unit/index.spec.js
@@ -41,6 +41,14 @@ describe("Test BullService started handler", () => {
 		name: "name",
 		process: jest.fn(),
 	};
+	
+	const namedWithOptions = {
+		name: "name",
+		process: jest.fn(),
+		options: {
+			prefix: "moleculer"
+		}
+	};
 
 	const multipleNamed = [
 		{
@@ -57,7 +65,7 @@ describe("Test BullService started handler", () => {
 		name: "name",
 		concurrency: 100,
 		process: jest.fn(),
-	}
+	};
 
 	const broker = new ServiceBroker({ logger: false});
 	const service = broker.createService({
@@ -68,6 +76,7 @@ describe("Test BullService started handler", () => {
 			"task.second": jest.fn(),
 			"task.concurrency": concurrency,
 			"task.name": named,
+			"task.namedWithOptions": namedWithOptions,
 			"task.name.multiple": multipleNamed,
 			"task.name.concurrency": namedconcurrency,
 		}
@@ -77,28 +86,31 @@ describe("Test BullService started handler", () => {
 
 	it("should be created queues", () => {
 		expect(service).toBeDefined();
-		expect(Object.keys(service.$queues).length).toBe(6);
+		expect(Object.keys(service.$queues).length).toBe(7);
 
 		expect(service.$queues["task.first"]).toBeDefined();
 		expect(service.$queues["task.second"]).toBeDefined();
 		expect(service.$queues["task.concurrency"]).toBeDefined();
 		expect(service.$queues["task.name"]).toBeDefined();
+		expect(service.$queues["task.namedWithOptions"]).toBeDefined();
 		expect(service.$queues["task.name.multiple"]).toBeDefined();
 		expect(service.$queues["task.name.concurrency"]).toBeDefined();
 
-		expect(Queue).toHaveBeenCalledTimes(6);
+		expect(Queue).toHaveBeenCalledTimes(7);
 		expect(Queue).toHaveBeenCalledWith("task.first", url, opts);
 		expect(Queue).toHaveBeenCalledWith("task.second", url, opts);
 		expect(Queue).toHaveBeenCalledWith("task.concurrency", url, opts);
 		expect(Queue).toHaveBeenCalledWith("task.name", url, opts);
+		expect(Queue).toHaveBeenCalledWith("task.namedWithOptions", url, namedWithOptions.options);
 		expect(Queue).toHaveBeenCalledWith("task.name.multiple", url, opts);
 		expect(Queue).toHaveBeenCalledWith("task.name.concurrency", url, opts);
 
-		expect(processCB).toHaveBeenCalledTimes(7);
+		expect(processCB).toHaveBeenCalledTimes(8);
 		expect(processCB).toHaveBeenCalledWith(expect.anything());
 		expect(processCB).toHaveBeenCalledWith(expect.anything());
 		expect(processCB).toHaveBeenCalledWith(concurrency.concurrency, expect.anything());
 		expect(processCB).toHaveBeenCalledWith(named.name, expect.anything());
+		expect(processCB).toHaveBeenCalledWith(namedWithOptions.name, expect.anything());
 		expect(processCB).toHaveBeenCalledWith(multipleNamed[0].name, expect.anything());
 		expect(processCB).toHaveBeenCalledWith(multipleNamed[1].name, expect.anything());
 		expect(processCB).toHaveBeenCalledWith(namedconcurrency.name, namedconcurrency.concurrency, expect.anything());
@@ -109,6 +121,7 @@ describe("Test BullService started handler", () => {
 		expect(service.getQueue("task.second")).toBeDefined();
 		expect(service.getQueue("task.concurrency")).toBeDefined();
 		expect(service.getQueue("task.name")).toBeDefined();
+		expect(service.getQueue("task.namedWithOptions")).toBeDefined();
 		expect(service.getQueue("task.name.multiple")).toBeDefined();
 		expect(service.getQueue("task.name.concurrency")).toBeDefined();
 	});


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR add an additional prop to the query definition in the service that allows a queue to have it's own options passed vs. the ones that are provided on the mixin. 


### :gem: Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### :scroll: Example code
```js
const QueueService = require("moleculer-bull");

broker.createService({
    name: "task-worker",
    mixins: [QueueService(process.env.REDIS_URL, {
      limiter: {
        max: 50000,
        duration: 1000000
      }
    })],

    queues: {
        "sheet.scrape": {
          concurrency: 5,
          async process(job: Job<JobDetailsType>) {
            this.logger.info("New job received!", job.data);
            job.progress(10);

            return this.Promise.resolve({
                done: true,
                id: job.data.id,
                worker: process.pid
            });
          },
        },
        "sheet.updateCell": {
          async process(job: Job<UpdateCellJobDetailsType>) {
            this.logger.info("New job received!", job.data);
            job.progress(10);

            return this.Promise.resolve({
                done: true,
                id: job.data.id,
                worker: process.pid
            });
          },
          options: {
            limiter: {
              max: 100,
              duration: 90000
            }
          }
        },
    }
}); 
``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] The unit tests for the add-on have been updated to test this specific flow which in turn as increased line coverage of the add-on

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas