### PR TITLE
Moleculer Bull: Fix createJob with queue in external service

### DIFF
--- a/packages/moleculer-bull/src/index.js
+++ b/packages/moleculer-bull/src/index.js
@@ -51,10 +51,14 @@ module.exports = function createService(url, queueOpts) {
 					// If queue options are present use them over the parent mixin options
 					// This allows a user to override the service wide queue options
 					let queueOptions = null;
+					// First check if queues has been defined and if so find the queue
 					const foundQueue = this.schema.queues && this.schema.queues[name];
+					// If found, pull the queue options out, which could be null or undefined
 					if(foundQueue){
 						queueOptions = foundQueue.options;
 					}
+					// Only apply custom queue options if they are present, if not use the global mixin
+					// options object
 					this.$queues[name] = Queue(name, url, queueOptions ? queueOptions : queueOpts);
 				}
 				return this.$queues[name];

--- a/packages/moleculer-bull/src/index.js
+++ b/packages/moleculer-bull/src/index.js
@@ -50,7 +50,11 @@ module.exports = function createService(url, queueOpts) {
 				if (!this.$queues[name]) {
 					// If queue options are present use them over the parent mixin options
 					// This allows a user to override the service wide queue options
-					let queueOptions = this.schema.queues[name].options;
+					let queueOptions = null;
+					const foundQueue = this.schema.queues && this.schema.queues[name];
+					if(foundQueue){
+						queueOptions = foundQueue.options;
+					}
 					this.$queues[name] = Queue(name, url, queueOptions ? queueOptions : queueOpts);
 				}
 				return this.$queues[name];

--- a/packages/moleculer-bull/test/unit/index.spec.js
+++ b/packages/moleculer-bull/test/unit/index.spec.js
@@ -10,15 +10,14 @@ let addDelayedCB = jest.fn();
 
 let Queue = require("bull");
 
+Queue.mockImplementation(() => ({
+	process: processCB,
+	add: addCB,
+}));
+
 const { ServiceBroker } = require("moleculer");
 const BullService = require("../../src");
 
-beforeEach(() => {
-	Queue.mockImplementation(() => ({
-		process: processCB,
-		add: addCB,
-	}));
-});
 
 describe("Test BullService constructor", () => {
 	const broker = new ServiceBroker({ logger: false});


### PR DESCRIPTION

## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

fix issue where a a job is added to a queue which was created in an external service

### :gem: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js
const QueueService = require("moleculer-bull");

const service = broker.createService({
    name: "task-worker",
    mixins: [QueueService(process.env.REDIS_URL, {
      limiter: {
        max: 50000,
        duration: 1000000
      }
    })],
    queues: undefined
}); 

service.createJob("task.foo", {})
	.then(data => {
		resolve(data);
	}).catch(err => {
		reject(err);
	});
``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] The unit tests for the add-on have been updated to test this specific flow of not having the queue defined within the service

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas