### PR TITLE
upgrade elasticsearch packages

### DIFF
--- a/packages/moleculer-elasticsearch/README.md
+++ b/packages/moleculer-elasticsearch/README.md
@@ -37,7 +37,7 @@ broker.createService({
     mixins: [ESService],
     settings: {
         elasticsearch: {
-            host: "http://elastic:changeme@<docker-hostname>:9200"
+            node: "http://elastic:changeme@<docker-hostname>:9200",
         }
     }
 });
@@ -47,7 +47,6 @@ broker.start()
     // Create a document
     .then(() => broker.call("elasticsearch.create", { 
         index: "demo", 
-        type: "default", 
         id: "1", 
         body: { name: "John Doe", age: 36 }
     }))
@@ -66,7 +65,7 @@ broker.start()
     }).then(res => console.log("Hits:", res.hits.hits)))
     
     // Remove document
-    .then(() => broker.call("elasticsearch.delete", { index: "demo", type: "default", id: "1" }))
+    .then(() => broker.call("elasticsearch.delete", { index: "demo", id: "1" }))
 ```
 
 # Settings
@@ -75,8 +74,7 @@ broker.start()
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `elasticsearch` | `Object` | **required** | Elasticsearch constructor options. [More options](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html) |
-| `elasticsearch.host` | `String` | **required** | Host |
-| `elasticsearch.apiVersion` | `String` | **required** | API version |
+| `elasticsearch.node` | `String` | **required** | Host |
 
 <!-- AUTO-CONTENT-END:SETTINGS -->
 
@@ -104,7 +102,6 @@ More info: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/c
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `index` | `String` | - | Default index for items which don’t provide one |
-| `type` | `String` | - | Default document type for items which don’t provide one |
 | `body` | `Array` | **required** | The request body, as either an array of objects or new-line delimited JSON objects |
 
 ### Results
@@ -123,7 +120,6 @@ More info: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/c
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `index` | `String` | **required** | The name of the index |
-| `type` | `String` | **required** | The type of the document |
 | `id` | `String` | **required** | Document ID |
 | `body` | `Object` | **required** | The request body, as either JSON or a JSON serializable object. |
 
@@ -143,7 +139,6 @@ More info: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/c
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `index` | `String` | **required** | The name of the index |
-| `type` | `String` | **required** | The type of the document |
 | `id` | `String` | - | Document ID |
 
 ### Results
@@ -162,7 +157,6 @@ More info: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/c
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `index` | `String` | **required** | The name of the index |
-| `type` | `String` | **required** | The type of the document |
 | `id` | `String` | **required** | Document ID |
 | `body` | `Object` | **required** | The request body, as either JSON or a JSON serializable object. |
 
@@ -182,7 +176,6 @@ More info: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/c
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `index` | `String` | **required** | The name of the index |
-| `type` | `String` | **required** | The type of the document |
 | `id` | `String` | **required** | Document ID |
 
 ### Results
@@ -201,7 +194,6 @@ More info: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/c
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `index` | `String`, `Array.<String>` | **required** | A comma-separated list of index names to search; use _all or empty string to perform the operation on all indices |
-| `type` | `String`, `Array.<String>` | **required** | A comma-separated list of document types to search; leave empty to perform the operation on all types |
 | `q` | `String` | - | Query in the [Lucene query string](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html) syntax. |
 | `body` | `Object` | - | The request body, as either JSON or a JSON serializable object. |
 
@@ -221,7 +213,6 @@ More info: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/c
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `index` | `String`, `Array.<String>` | **required** | A comma-separated list of indices to restrict the results. |
-| `type` | `String`, `Array.<String>` | **required** | A comma-separated list of types to restrict the results. |
 | `q` | `String` | - | Query in the Lucene query string syntax. |
 | `body` | `Object` | - | The request body, as either JSON or a JSON serializable object. |
 

--- a/packages/moleculer-elasticsearch/examples/simple/index.js
+++ b/packages/moleculer-elasticsearch/examples/simple/index.js
@@ -15,7 +15,7 @@ broker.createService({
 	mixins: [ESService],
 	settings: {
 		elasticsearch: {
-			host: "http://elastic:changeme@192.168.0.181:9200"
+			node: "http://elastic:changeme@192.168.0.181:9200"
 		}
 	}
 });
@@ -34,17 +34,17 @@ broker.start()
 	// Update a document
 	.then(() => console.log(chalk.yellow.bold("\n--- UPDATE JANE ---")))
 	.then(() => broker.call("elasticsearch.update", { index: "demo", type: "default", id: "2", body: { doc: { age: 32 } } }).then(console.log))
-	
+
 	.delay(1000)
 
 	// Get a document by ID
 	.then(() => console.log(chalk.yellow.bold("\n--- GET JANE ---")))
 	.then(() => broker.call("elasticsearch.get", { index: "demo", type: "default", id: "2" }).then(console.log))
-	
+
 	// Search with 'q'
 	.then(() => console.log(chalk.yellow.bold("\n--- SEARCH Q ---")))
 	.then(() => broker.call("elasticsearch.search", { q: 'name:"*doe"' }).then(res => { console.log(res); console.log(chalk.yellow.bold("\nHits:\n"), res.hits.hits); }))
-	
+
 	// Search with query
 	.then(() => console.log(chalk.yellow.bold("\n--- SEARCH QUERY ---")))
 	.then(() => broker.call("elasticsearch.search", { body: {
@@ -54,7 +54,7 @@ broker.start()
 			}
 		}
 	} }).then(res => { console.log(res); console.log(chalk.yellow.bold("\nHits:\n"), res.hits.hits); }))
-	
+
 	// Count with 'q'
 	.then(() => console.log(chalk.yellow.bold("\n--- COUNT Q ---")))
 	.then(() => broker.call("elasticsearch.count", { q: 'name:"*doe"' }).then(console.log))
@@ -65,5 +65,5 @@ broker.start()
 	.then(() => console.log(chalk.yellow.bold("\n--- DROP ---")))
 	.then(() => broker.call("elasticsearch.delete", { index: "demo", type: "default", id: "1" }).then(console.log))
 	.then(() => broker.call("elasticsearch.delete", { index: "demo", type: "default", id: "2" }).then(console.log))
-	
+
 	.catch(console.error);

--- a/packages/moleculer-elasticsearch/package.json
+++ b/packages/moleculer-elasticsearch/package.json
@@ -31,8 +31,8 @@
     "benchmarkify": "2.1.2",
     "coveralls": "^3.1.0",
     "eslint": "^6.5.1",
-    "jest": "^24.9.0",
-    "jest-cli": "^24.9.0",
+    "jest": "^26.6.3",
+    "jest-cli": "^26.6.3",
     "lolex": "^5.1.0",
     "moleculer": "^0.14.8",
     "moleculer-docgen": "^0.3.0",
@@ -50,6 +50,6 @@
     "node": ">= 8.x.x"
   },
   "dependencies": {
-    "elasticsearch": "^16.7.1"
+    "@elastic/elasticsearch": "^8.1.0"
   }
 }

--- a/packages/moleculer-elasticsearch/src/index.js
+++ b/packages/moleculer-elasticsearch/src/index.js
@@ -6,7 +6,7 @@
 
 "use strict";
 
-const Elasticsearch = require("elasticsearch");
+const {Client} = require("@elastic/elasticsearch");
 
 /**
  * Elasticsearch service for Moleculer.
@@ -30,10 +30,7 @@ module.exports = {
 		/** @type {Object} Elasticsearch constructor options. [More options](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html) */
 		elasticsearch: {
 			/** @type {String} Host */
-			host: process.env.ELASTICSEARCH_HOST || "http://localhost:9200",
-
-			/** @type {String} API version */
-			apiVersion: "5.4"
+			node: process.env.ELASTICSEARCH_HOST || "http://localhost:9200",
 		}
 	},
 
@@ -49,7 +46,6 @@ module.exports = {
 		 * @actions
 		 *
 		 * @param {String=} index - Default index for items which don’t provide one
-		 * @param {String=} type - Default document type for items which don’t provide one
 		 * @param {Array} body - The request body, as either an array of objects or new-line delimited JSON objects
 		 *
 		 * @returns {Object} Elasticsearch response object
@@ -57,7 +53,6 @@ module.exports = {
 		bulk: {
 			params: {
 				index: { type: "string", optional: true },
-				type: { type: "string", optional: true },
 				body: { type: "array" }
 			},
 			handler(ctx) {
@@ -73,7 +68,6 @@ module.exports = {
 		 * @actions
 		 *
 		 * @param {String} index - The name of the index
-		 * @param {String} type - The type of the document
 		 * @param {String} id - Document ID
 		 * @param {Object} body - The request body, as either JSON or a JSON serializable object.
 		 *
@@ -82,7 +76,6 @@ module.exports = {
 		create: {
 			params: {
 				index: { type: "string" },
-				type: { type: "string" },
 				id: { type: "string" },
 				body: { type: "object" }
 			},
@@ -107,7 +100,6 @@ module.exports = {
 		get: {
 			params: {
 				index: { type: "string" },
-				type: { type: "string" },
 				id: { type: "string" }
 			},
 			handler(ctx) {
@@ -123,7 +115,6 @@ module.exports = {
 		 * @actions
 		 *
 		 * @param {String} index - The name of the index
-		 * @param {String} type - The type of the document
 		 * @param {String} id - Document ID
 		 * @param {Object} body - The request body, as either JSON or a JSON serializable object.
 		 *
@@ -132,7 +123,6 @@ module.exports = {
 		update: {
 			params: {
 				index: { type: "string" },
-				type: { type: "string" },
 				id: { type: "string" },
 				body: { type: "object" }
 			},
@@ -150,7 +140,6 @@ module.exports = {
 		 * @actions
 		 *
 		 * @param {String} index - The name of the index
-		 * @param {String} type - The type of the document
 		 * @param {String} id - Document ID
 		 *
 		 * @returns {Object} Elasticsearch response object
@@ -158,7 +147,6 @@ module.exports = {
 		delete: {
 			params: {
 				index: { type: "string" },
-				type: { type: "string" },
 				id: { type: "string" }
 			},
 			handler(ctx) {
@@ -184,10 +172,6 @@ module.exports = {
 		search: {
 			params: {
 				/*index: [
-					{ type: "string", optional: true },
-					{ type: "array", items: "string", optional: true }
-				],
-				type: [
 					{ type: "string", optional: true },
 					{ type: "array", items: "string", optional: true }
 				],*/
@@ -216,10 +200,6 @@ module.exports = {
 		count: {
 			params: {
 				/*index: [
-					{ type: "string", optional: true },
-					{ type: "array", items: "string", optional: true }
-				],
-				type: [
 					{ type: "string", optional: true },
 					{ type: "array", items: "string", optional: true }
 				],*/
@@ -272,9 +252,9 @@ module.exports = {
 	 * Service started lifecycle event handler
 	 */
 	started() {
-		this.client = new Elasticsearch.Client(this.settings.elasticsearch);
+		this.client = new Client(this.settings.elasticsearch);
 
-		return this.client.ping({ requestTimeout: this.settings.elasticsearch.requestTimeout || 5000 });
+		return this.client;
 	},
 
 	/**

--- a/packages/moleculer-elasticsearch/test/unit/index.spec.js
+++ b/packages/moleculer-elasticsearch/test/unit/index.spec.js
@@ -3,8 +3,8 @@
 const { ServiceBroker } = require("moleculer");
 const ESService = require("../../src");
 
-jest.mock("elasticsearch");
-const Elasticsearch = require("elasticsearch");
+jest.mock("@elastic/elasticsearch");
+const Elasticsearch = require("@elastic/elasticsearch");
 
 Elasticsearch.Client = jest.fn(() => {
 	return {
@@ -45,7 +45,6 @@ describe("Test Elasticsearch service", () => {
 	it("should call client.bulk", () => {
 		let p = {
 			index: "test",
-			type: "def",
 			body: [
 				{ id: 1, name: "John" },
 				{ id: 2, name: "Jane" }
@@ -61,7 +60,6 @@ describe("Test Elasticsearch service", () => {
 	it("should call client.create", () => {
 		let p = {
 			index: "test",
-			type: "def",
 			id: "5",
 			body: { id: "5", name: "John" }
 		};
@@ -75,7 +73,6 @@ describe("Test Elasticsearch service", () => {
 	it("should call client.get", () => {
 		let p = {
 			index: "test",
-			type: "def",
 			id: "5"
 		};
 
@@ -88,7 +85,6 @@ describe("Test Elasticsearch service", () => {
 	it("should call client.update", () => {
 		let p = {
 			index: "test",
-			type: "def",
 			id: "5",
 			body: { id: "5", name: "John" }
 		};
@@ -102,7 +98,6 @@ describe("Test Elasticsearch service", () => {
 	it("should call client.delete", () => {
 		let p = {
 			index: "test",
-			type: "def",
 			id: "5",
 		};
 
@@ -165,7 +160,6 @@ describe("Test Elasticsearch service", () => {
 			api: "xyz",
 			params: {
 				index: "custom",
-				type: "default"
 			}
 		};
 


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
In this PR I have resolved the below issues

1. Remove the deprecated **elasticsearch** package (https://www.npmjs.com/package/elasticsearch) 
2. Used the supported elasticsearch package "@elastic/elasticsearch" (https://www.npmjs.com/package/@elastic/elasticsearch)
3. Support the latest elastic search version 8.1 
4. Fix the type issue in latest version elasticsearch has removed the document type. For eg. type="_doc" (https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html)
5. Removed the apiversion parameter. It will take default latest version

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
